### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Setup.py
+++ b/Setup.py
@@ -24,7 +24,7 @@ VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'unidecode', 'phonetics', 'fuzzywuzzy'
+    'unidecode', 'phonetics', 'rapidfuzz'
 ]
 
 # What packages are optional?

--- a/geodata/MatchScore.py
+++ b/geodata/MatchScore.py
@@ -21,7 +21,7 @@ import copy
 import logging
 
 # import python-Levenshtein 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from geodata import Loc, Normalize, Geodata, GeoUtil, GeoSearch
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it faster than FuzzyWuzzy.